### PR TITLE
Add setup script to be sourced during Notebook start

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Script to be sourced on launch of the Gradient Notebook
+
+gc-reset

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 # Script to be sourced on launch of the Gradient Notebook
 
 gc-reset


### PR DESCRIPTION
PR For IP review

Text for the external PR:
> As we've discussed internally, can you run `source setup.sh` in the command executed to launch the run-time?